### PR TITLE
HOCS-2239: Remove redundant certs container

### DIFF
--- a/kube/kd/deployment.yaml
+++ b/kube/kd/deployment.yaml
@@ -135,38 +135,6 @@ spec:
               name: frontend-keycloak-secret
               readOnly: true
 
-        - name: certs
-          image: quay.io/ukhomeofficedigital/cfssl-sidekick:v0.0.9
-          securityContext:
-            runAsNonRoot: true
-            capabilities:
-              drop:
-                - SETUID
-                - SETGID
-          args:
-            - --certs=/certs
-            - --domain=hocs-extracts.${KUBE_NAMESPACE}.svc.cluster.local
-            - --expiry=8760h
-            - --command=/usr/local/scripts/trigger_nginx_reload.sh
-          env:
-            - name: KUBE_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-          volumeMounts:
-            - name: certs
-              mountPath: /certs
-            - name: bundle
-              mountPath: /etc/ssl/certs
-              readOnly: true
-          resources:
-            limits:
-              memory: 96Mi
-              cpu: 400m
-            requests:
-              memory: 96Mi
-              cpu: 100m
-
         - name: proxy
           image: quay.io/ukhomeofficedigital/nginx-proxy:v4.2.0
           securityContext:


### PR DESCRIPTION
The certs container exists to generate new certs and restart the proxy every 90 days of uptime.
Now that we start the service each morning and generate a certificate each morning this is no longer required.